### PR TITLE
Make cosmetic changes

### DIFF
--- a/common/types/src/base/generic_types.rs
+++ b/common/types/src/base/generic_types.rs
@@ -6,14 +6,21 @@ use std::{
 
 /// `Arc<Mutex<T>>` alias type
 pub type AM<T> = Arc<Mutex<T>>;
-pub trait AMTrait<T> {
-    fn new_am(t: T) -> AM<T>;
+pub trait AMTrait<T: ?Sized> {
+    fn new_am(t: T) -> AM<T>
+    where
+        T: Sized;
     fn lock_un(&self) -> MutexGuard<T>;
 }
-impl<T> AMTrait<T> for AM<T> {
-    fn new_am(t: T) -> AM<T> {
+
+impl<T: ?Sized> AMTrait<T> for AM<T> {
+    fn new_am(t: T) -> AM<T>
+    where
+        T: Sized,
+    {
         Arc::new(Mutex::new(t))
     }
+
     fn lock_un(&self) -> MutexGuard<T> {
         self.lock().unwrap()
     }

--- a/shop/application/src/event/event_publisher_impl.rs
+++ b/shop/application/src/event/event_publisher_impl.rs
@@ -31,9 +31,7 @@ impl<Event: Debug + Clone + Hash + Eq> EventPublisherImpl<Event> {
     }
 
     fn send_events(&self, listeners: Vec<AM<dyn DomainEventListener<Event>>>, event: Event) {
-        listeners
-            .iter()
-            .for_each(|l| l.lock().unwrap().handle(&event))
+        listeners.iter().for_each(|l| l.lock_un().handle(&event))
     }
 }
 
@@ -85,15 +83,13 @@ mod test {
 
         let test_event_listener = &publisher
             .get_listener(DomainEventEnum::TestEvent(TestEvent::default()))
-            .lock()
-            .unwrap();
+            .lock_un();
 
         let another_test_event_listener = &publisher
             .get_listener(DomainEventEnum::AnotherTestEvent(
                 AnotherTestEvent::default(),
             ))
-            .lock()
-            .unwrap();
+            .lock_un();
 
         assert_eq!(test_event_listener.get_events(), &vec![test_event]);
         assert_eq!(

--- a/shop/domain/src/cart/cart.rs
+++ b/shop/domain/src/cart/cart.rs
@@ -1,7 +1,7 @@
 use std::collections::HashMap;
 
 use common::types::{
-    base::{AM, DomainEntity, DomainEntityTrait, Version},
+    base::{AM, AMTrait, DomainEntity, DomainEntityTrait, Version},
     common::Count,
 };
 use derive_getters::Getters;
@@ -38,7 +38,7 @@ impl Cart {
     pub fn create(id_generator: AM<dyn CartIdGenerator>, for_customer: CustomerId) -> Self {
         let mut cart = Self {
             entity_params: DomainEntity {
-                id: id_generator.lock().unwrap().generate(),
+                id: id_generator.lock_un().generate(),
                 version: Version::default(),
                 events: vec![],
             },
@@ -107,10 +107,7 @@ pub enum CartError {
 mod tests {
     use std::mem::discriminant;
 
-    use common::{
-        test_fixtures::rnd_count,
-        types::base::{AM, AMTrait},
-    };
+    use common::test_fixtures::rnd_count;
 
     use super::*;
     use crate::test_fixtures::{rnd_cart, rnd_cart_id, rnd_customer_id, rnd_meal};

--- a/shop/domain/src/menu/meal.rs
+++ b/shop/domain/src/menu/meal.rs
@@ -1,7 +1,7 @@
 use std::fmt::Debug;
 
 use common::types::{
-    base::{AM, DomainEntity, DomainEntityTrait, Version},
+    base::{AM, AMTrait, DomainEntity, DomainEntityTrait, Version},
     errors::BusinessError,
 };
 use derive_getters::Getters;
@@ -53,10 +53,10 @@ impl Meal {
         description: MealDescription,
         price: Price,
     ) -> Result<Meal, MealError> {
-        if meal_exists.lock().unwrap().invoke(&name) {
+        if meal_exists.lock_un().invoke(&name) {
             Err(MealError::AlreadyExistsWithSameNameError)
         } else {
-            let id = id_generator.lock().unwrap().generate();
+            let id = id_generator.lock_un().generate();
 
             //     .map_err(|_e: Error| MealError::IdGenerationError)?;
             let mut meal = Meal::new(
@@ -108,8 +108,6 @@ impl BusinessError for MealError {}
 #[cfg(test)]
 mod tests {
     use std::{any::type_name_of_val, sync::atomic::AtomicI64};
-
-    use common::types::base::{AM, AMTrait};
 
     use super::*;
     use crate::test_fixtures::{

--- a/shop/in_memory_persistence/src/cart/in_memory_cart_repository.rs
+++ b/shop/in_memory_persistence/src/cart/in_memory_cart_repository.rs
@@ -1,6 +1,9 @@
 use std::collections::HashMap;
 
-use common::{events::DomainEventPublisher, types::base::AM};
+use common::{
+    events::DomainEventPublisher,
+    types::base::{AM, AMTrait},
+};
 use derivative::Derivative;
 use derive_new::new;
 use domain::cart::{
@@ -28,7 +31,7 @@ impl CartPersister for InMemoryCartRepository {
         dbg!(&cart);
         let popped_events = cart.pop_events();
         dbg!(&popped_events);
-        self.event_publisher.lock().unwrap().publish(&popped_events);
+        self.event_publisher.lock_un().publish(&popped_events);
         self.storage.insert(*cart.for_customer(), cart);
     }
 }
@@ -41,7 +44,6 @@ impl CartRemover for InMemoryCartRepository {
 
 #[cfg(test)]
 mod tests {
-    use common::types::base::{AM, AMTrait};
     use domain::{cart::cart_events::MealAddedToCartDomainEvent, test_fixtures::*};
 
     use super::*;

--- a/shop/in_memory_persistence/src/menu/in_memory_meal_repository.rs
+++ b/shop/in_memory_persistence/src/menu/in_memory_meal_repository.rs
@@ -1,6 +1,9 @@
 use std::{collections::HashMap, fmt::Debug};
 
-use common::{events::DomainEventPublisher, types::base::AM};
+use common::{
+    events::DomainEventPublisher,
+    types::base::{AM, AMTrait},
+};
 use derivative::Derivative;
 use derive_new::new;
 use domain::menu::{
@@ -19,10 +22,7 @@ pub struct InMemoryMealRepository {
 
 impl MealPersister for InMemoryMealRepository {
     fn save(&mut self, mut meal: Meal) {
-        self.event_publisher
-            .lock()
-            .unwrap()
-            .publish(&meal.pop_events());
+        self.event_publisher.lock_un().publish(&meal.pop_events());
         self.storage.insert(*meal.id(), meal);
     }
 }
@@ -54,7 +54,6 @@ impl MealExtractor for InMemoryMealRepository {
 mod tests {
     use std::any::{type_name, type_name_of_val};
 
-    use common::types::base::{AM, AMTrait};
     use domain::{menu::meal_events::MealRemovedFromMenuDomainEvent, test_fixtures::*};
 
     use super::*;

--- a/shop/in_memory_persistence/src/order/in_memory_shop_order_repository.rs
+++ b/shop/in_memory_persistence/src/order/in_memory_shop_order_repository.rs
@@ -1,6 +1,9 @@
 use std::collections::BTreeMap;
 
-use common::{events::DomainEventPublisher, types::base::AM};
+use common::{
+    events::DomainEventPublisher,
+    types::base::{AM, AMTrait},
+};
 use derivative::Derivative;
 use derive_new::new;
 use domain::{
@@ -23,10 +26,7 @@ pub struct InMemoryShopOrderRepository {
 
 impl ShopOrderPersister for InMemoryShopOrderRepository {
     fn save(&mut self, mut order: ShopOrder) {
-        self.event_publisher
-            .lock()
-            .unwrap()
-            .publish(&order.pop_events());
+        self.event_publisher.lock_un().publish(&order.pop_events());
         self.storage.insert(*order.id(), order);
     }
 }
@@ -60,7 +60,6 @@ impl ShopOrderExtractor for InMemoryShopOrderRepository {
 
 #[cfg(test)]
 mod tests {
-    use common::types::base::{AM, AMTrait};
     use domain::{order::customer_order_events::ShopOrderCompletedDomainEvent, test_fixtures::*};
 
     use super::*;

--- a/shop/postgres_persistence/src/postgres_meal_repository.rs
+++ b/shop/postgres_persistence/src/postgres_meal_repository.rs
@@ -1,4 +1,7 @@
-use common::{events::DomainEventPublisher, types::base::AM};
+use common::{
+    events::DomainEventPublisher,
+    types::base::{AM, AMTrait},
+};
 use derivative::Derivative;
 use derive_new::new;
 use diesel::{ExpressionMethods, PgConnection, QueryDsl, RunQueryDsl, SelectableHelper};
@@ -67,7 +70,7 @@ impl MealPersister for PostgresMealRepository {
             if !flag {
                 self.update(meal_param);
             }
-            self.event_publisher.lock().unwrap().publish(&events);
+            self.event_publisher.lock_un().publish(&events);
         }
     }
 }

--- a/shop/usecase/src/menu/invariant/meal_already_exists_uses_meal_extractor.rs
+++ b/shop/usecase/src/menu/invariant/meal_already_exists_uses_meal_extractor.rs
@@ -1,4 +1,4 @@
-use common::types::base::AM;
+use common::types::base::{AM, AMTrait};
 use derive_new::new;
 use domain::menu::{meal_already_exists::MealAlreadyExists, value_objects::meal_name::MealName};
 
@@ -11,7 +11,7 @@ pub struct MealAlreadyExistsUsesMealExtractor {
 
 impl MealAlreadyExists for MealAlreadyExistsUsesMealExtractor {
     fn invoke(&mut self, name: &MealName) -> bool {
-        let meal_found_by_get = self.extractor.lock().unwrap().get_by_name(name);
+        let meal_found_by_get = self.extractor.lock_un().get_by_name(name);
         let meal_found_by_get_is_removed = *meal_found_by_get.clone().unwrap_or_default().removed();
         meal_found_by_get.is_some() & !meal_found_by_get_is_removed
     }
@@ -19,7 +19,6 @@ impl MealAlreadyExists for MealAlreadyExistsUsesMealExtractor {
 
 #[cfg(test)]
 mod tests {
-    use common::types::base::{AM, AMTrait};
     use domain::test_fixtures::{rnd_meal, rnd_meal_name};
 
     use super::*;
@@ -39,8 +38,7 @@ mod tests {
         assert!(result);
 
         rule.extractor
-            .lock()
-            .unwrap()
+            .lock_un()
             .downcast_ref::<MockMealExtractor>()
             .unwrap()
             .verify_invoked_get_by_name(meal.name());
@@ -59,8 +57,7 @@ mod tests {
 
         assert!(!result);
         rule.extractor
-            .lock()
-            .unwrap()
+            .lock_un()
             .downcast_ref::<MockMealExtractor>()
             .unwrap()
             .verify_invoked_get_by_name(meal.name());
@@ -76,8 +73,7 @@ mod tests {
 
         assert!(!result);
         rule.extractor
-            .lock()
-            .unwrap()
+            .lock_un()
             .downcast_ref::<MockMealExtractor>()
             .unwrap()
             .verify_invoked_get_by_name(&meal_name);

--- a/shop/usecase/src/menu/scenario/add_meal_to_menu_use_case.rs
+++ b/shop/usecase/src/menu/scenario/add_meal_to_menu_use_case.rs
@@ -1,6 +1,6 @@
 use std::fmt::Debug;
 
-use common::types::base::{AM, DomainEventTrait};
+use common::types::base::{AM, AMTrait, DomainEventTrait};
 use derive_new::new;
 use domain::menu::{
     meal::Meal,
@@ -39,10 +39,7 @@ impl AddMealToMenu for AddMealToMenuUseCase {
             description.clone(),
             price.clone(),
         )?;
-        self.meal_persister
-            .lock()
-            .unwrap()
-            .save(new_meal_in_menu.clone());
+        self.meal_persister.lock_un().save(new_meal_in_menu.clone());
         Ok(*new_meal_in_menu.id())
     }
 }
@@ -51,7 +48,6 @@ impl DomainEventTrait for AddMealToMenuUseCase {}
 
 #[cfg(test)]
 mod tests {
-    use common::types::base::{AM, AMTrait};
     use domain::test_fixtures::*;
 
     use super::*;

--- a/shop/usecase/src/menu/scenario/get_meal_by_id_use_case.rs
+++ b/shop/usecase/src/menu/scenario/get_meal_by_id_use_case.rs
@@ -1,4 +1,4 @@
-use common::types::base::AM;
+use common::types::base::{AM, AMTrait};
 use derive_new::new;
 use domain::menu::value_objects::meal_id::MealId;
 
@@ -15,7 +15,7 @@ pub struct GetMealByIdUseCase {
 
 impl GetMealById for GetMealByIdUseCase {
     fn execute(&mut self, id: &MealId) -> Result<MealInfo, GetMealByIdUseCaseError> {
-        match self.meal_extractor.lock().unwrap().get_by_id(id) {
+        match self.meal_extractor.lock_un().get_by_id(id) {
             res if res.is_some() && res.clone().unwrap().visible() => {
                 let res = res.unwrap();
                 Ok(MealInfo::from(res))
@@ -27,7 +27,6 @@ impl GetMealById for GetMealByIdUseCase {
 
 #[cfg(test)]
 mod tests {
-    use common::types::base::{AM, AMTrait};
     use domain::test_fixtures::*;
 
     use super::*;
@@ -44,8 +43,7 @@ mod tests {
         assert_eq!(result, Err(GetMealByIdUseCaseError::MealNotFound));
         use_case
             .meal_extractor
-            .lock()
-            .unwrap()
+            .lock_un()
             .downcast_ref::<MockMealExtractor>()
             .unwrap()
             .verify_invoked_get_by_id(meal_id);
@@ -65,8 +63,7 @@ mod tests {
         assert_eq!(result, Err(GetMealByIdUseCaseError::MealNotFound));
         use_case
             .meal_extractor
-            .lock()
-            .unwrap()
+            .lock_un()
             .downcast_ref::<MockMealExtractor>()
             .unwrap()
             .verify_invoked_get_by_id(meal.id());
@@ -96,8 +93,7 @@ mod tests {
         );
         use_case
             .meal_extractor
-            .lock()
-            .unwrap()
+            .lock_un()
             .downcast_ref::<MockMealExtractor>()
             .unwrap()
             .verify_invoked_get_by_id(meal.id());

--- a/shop/usecase/src/menu/scenario/get_menu_use_case.rs
+++ b/shop/usecase/src/menu/scenario/get_menu_use_case.rs
@@ -1,4 +1,4 @@
-use common::types::base::AM;
+use common::types::base::{AM, AMTrait};
 use derive_new::new;
 
 use crate::menu::{
@@ -13,8 +13,7 @@ pub struct GetMenuUseCase {
 impl GetMenu for GetMenuUseCase {
     fn execute(&self) -> Vec<MealInfo> {
         self.meal_extractor
-            .lock()
-            .unwrap()
+            .lock_un()
             .get_all()
             .into_iter()
             .map(MealInfo::from)
@@ -24,7 +23,6 @@ impl GetMenu for GetMenuUseCase {
 
 #[cfg(test)]
 mod tests {
-    use common::types::base::{AM, AMTrait};
     use domain::test_fixtures::*;
 
     use super::*;
@@ -40,8 +38,7 @@ mod tests {
         assert!(menu.is_empty());
         use_case
             .meal_extractor
-            .lock()
-            .unwrap()
+            .lock_un()
             .downcast_ref::<MockMealExtractor>()
             .unwrap()
             .verify_invoked_get_all();
@@ -69,8 +66,7 @@ mod tests {
         );
         use_case
             .meal_extractor
-            .lock()
-            .unwrap()
+            .lock_un()
             .downcast_ref::<MockMealExtractor>()
             .unwrap()
             .verify_invoked_get_all();

--- a/shop/usecase/src/menu/scenario/remove_meal_from_menu_use_case.rs
+++ b/shop/usecase/src/menu/scenario/remove_meal_from_menu_use_case.rs
@@ -1,4 +1,4 @@
-use common::types::base::AM;
+use common::types::base::{AM, AMTrait};
 use derive_new::new;
 use domain::menu::value_objects::meal_id::MealId;
 
@@ -17,21 +17,19 @@ impl RemoveMealFromMenu for RemoveMealFromMenuUseCase {
     fn execute(&mut self, id: &MealId) -> Result<(), RemoveMealFromMenuUseCaseError> {
         let mut meal = self
             .meal_extractor
-            .lock()
-            .unwrap()
+            .lock_un()
             .get_by_id(id)
             .map_or(Err(RemoveMealFromMenuUseCaseError::MealNotFound), |meal| {
                 Ok(meal)
             })?;
         meal.remove_meal_from_menu();
-        self.meal_persister.lock().unwrap().save(meal);
+        self.meal_persister.lock_un().save(meal);
         Ok(())
     }
 }
 
 #[cfg(test)]
 mod tests {
-    use common::types::base::{AM, AMTrait};
     use domain::test_fixtures::*;
 
     use super::*;

--- a/shop/usecase/src/order/invariants/customer_has_active_order_impl.rs
+++ b/shop/usecase/src/order/invariants/customer_has_active_order_impl.rs
@@ -1,4 +1,4 @@
-use common::types::base::AM;
+use common::types::base::{AM, AMTrait};
 use derive_new::new;
 use domain::{
     cart::value_objects::customer_id::CustomerId,
@@ -16,8 +16,7 @@ impl CustomerHasActiveOrder for CustomerHasActiveOrderImpl {
     fn invoke(&mut self, for_customer: &CustomerId) -> bool {
         let last_order = self
             .shop_order_extractor
-            .lock()
-            .unwrap()
+            .lock_un()
             .get_last_order(for_customer);
         last_order.is_some() && last_order.unwrap().is_active()
     }
@@ -25,7 +24,6 @@ impl CustomerHasActiveOrder for CustomerHasActiveOrderImpl {
 
 #[cfg(test)]
 mod tests {
-    use common::types::base::{AM, AMTrait};
     use domain::test_fixtures::*;
 
     use super::*;

--- a/shop/usecase/src/order/providers/get_meal_price_using_extractor.rs
+++ b/shop/usecase/src/order/providers/get_meal_price_using_extractor.rs
@@ -1,4 +1,4 @@
-use common::types::base::AM;
+use common::types::base::{AM, AMTrait};
 use derive_new::new;
 use domain::{
     menu::value_objects::{meal_id::MealId, price::Price},
@@ -9,7 +9,7 @@ use crate::menu::access::meal_extractor::MealExtractor;
 
 impl GetMealPrice for GetMealPriceUsingExtractor {
     fn invoke(&self, for_meal_id: &MealId) -> Price {
-        let meal = &self.extractor.lock().unwrap().get_by_id(for_meal_id);
+        let meal = &self.extractor.lock_un().get_by_id(for_meal_id);
         assert!(meal.is_some(), "Meal #{:?} not found", for_meal_id);
         meal.clone().unwrap().price().clone()
     }
@@ -23,7 +23,6 @@ pub struct GetMealPriceUsingExtractor {
 #[cfg(test)]
 mod tests {
     use assert_panic::assert_panic;
-    use common::types::base::{AM, AMTrait};
     use domain::test_fixtures::*;
 
     use super::*;

--- a/shop/usecase/src/order/scenarios/complete_order_use_case.rs
+++ b/shop/usecase/src/order/scenarios/complete_order_use_case.rs
@@ -1,4 +1,4 @@
-use common::types::base::AM;
+use common::types::base::{AM, AMTrait};
 use derive_new::new;
 use domain::order::value_objects::shop_order_id::ShopOrderId;
 
@@ -16,15 +16,14 @@ pub struct CompleteOrderUseCase {
 impl CompleteOrder for CompleteOrderUseCase {
     fn execute(&self, order_id: &ShopOrderId) -> Result<(), CompleteOrderUseCaseError> {
         self.shop_order_extractor
-            .lock()
-            .unwrap()
+            .lock_un()
             .get_by_id(order_id)
             .map_or(
                 Err(CompleteOrderUseCaseError::OrderNotFound),
                 |mut order| {
                     order
                         .complete()
-                        .map(|_| self.shop_order_persister.lock().unwrap().save(order))
+                        .map(|_| self.shop_order_persister.lock_un().save(order))
                         .map_err(|_| CompleteOrderUseCaseError::InvalidOrderState)
                 },
             )
@@ -33,7 +32,6 @@ impl CompleteOrder for CompleteOrderUseCase {
 
 #[cfg(test)]
 mod tests {
-    use common::types::base::{AM, AMTrait};
     use domain::test_fixtures::*;
 
     use super::*;

--- a/shop/usecase/src/order/scenarios/get_last_order_state_use_case.rs
+++ b/shop/usecase/src/order/scenarios/get_last_order_state_use_case.rs
@@ -1,4 +1,4 @@
-use common::types::base::AM;
+use common::types::base::{AM, AMTrait};
 use derive_new::new;
 use domain::{cart::value_objects::customer_id::CustomerId, order::shop_order::OrderState};
 
@@ -18,8 +18,7 @@ impl GetLastOrderState for GetLastOrderStateUseCase {
         for_customer: &CustomerId,
     ) -> Result<OrderState, GetLastOrderStateUseCaseError> {
         self.shop_order_extractor
-            .lock()
-            .unwrap()
+            .lock_un()
             .get_last_order(for_customer)
             .map_or(Err(GetLastOrderStateUseCaseError::OrderNotFound), |order| {
                 Ok(order.state().clone())
@@ -29,7 +28,6 @@ impl GetLastOrderState for GetLastOrderStateUseCase {
 
 #[cfg(test)]
 mod tests {
-    use common::types::base::{AM, AMTrait};
     use domain::test_fixtures::*;
 
     use super::*;

--- a/shop/usecase/src/order/scenarios/pay_order_handler.rs
+++ b/shop/usecase/src/order/scenarios/pay_order_handler.rs
@@ -1,4 +1,4 @@
-use common::types::base::AM;
+use common::types::base::{AM, AMTrait};
 use derive_new::new;
 use domain::order::value_objects::shop_order_id::ShopOrderId;
 
@@ -16,13 +16,12 @@ pub struct PayOrderHandler {
 impl PayOrder for PayOrderHandler {
     fn execute(&self, order_id: &ShopOrderId) -> Result<(), PayOrderHandlerError> {
         self.shop_order_extractor
-            .lock()
-            .unwrap()
+            .lock_un()
             .get_by_id(order_id)
             .map_or(Err(PayOrderHandlerError::OrderNotFound), |mut order| {
                 order
                     .pay()
-                    .map(|_| self.shop_order_persister.lock().unwrap().save(order))
+                    .map(|_| self.shop_order_persister.lock_un().save(order))
                     .map_err(|_| PayOrderHandlerError::InvalidOrderState)
             })
     }
@@ -30,7 +29,6 @@ impl PayOrder for PayOrderHandler {
 
 #[cfg(test)]
 mod tests {
-    use common::types::base::{AM, AMTrait};
     use domain::test_fixtures::*;
 
     use super::*;


### PR DESCRIPTION
This Pull Request introduces changes across multiple files to streamline and improve the handling of thread-safe object locking within the project. The `AM` trait and its methods were updated to remove manual locks (`lock().unwrap()`) with a new `lock_un` method, standardizing and simplifying locking operations. In addition, unused imports of `AMTrait` were cleaned up in test modules.

**Main Changes:**

* Updated `AMTrait` and `AM` implementation:
  * Added `lock_un` as a replacement for `lock().unwrap()` to improve API usability and reduce boilerplate.
  * Adjusted implementations in `generic_types.rs` accordingly.
* Code adjustments using the `new lock_un method`:
  * Replaced `lock().unwrap()` calls with `lock_un()` across functional files (`cart.rs`, `meal.rs`, `shop_order.rs`, etc.).
* Imports cleanup:
  * Removed unused `AMTrait` imports in test modules.
* Improved maintainability:
  * Unified object locking logic which makes the codebase easier to read and maintain.

These changes enhance both the efficiency and clarity of the codebase.