### PR TITLE
Add `delegate_fields` proc-macro to reduce boilerplate

### DIFF
--- a/common/Cargo.toml
+++ b/common/Cargo.toml
@@ -27,6 +27,7 @@ uuid = { version = "1", features = ["v4", "fast-rng", "macro-diagnostics", "serd
 derive-getters = "0"
 async-trait = "0.1"
 tokio = "1"
+ambassador = "0.4"
 
 rstest = "0"
 fake = "4"

--- a/common/Cargo.toml
+++ b/common/Cargo.toml
@@ -26,29 +26,27 @@ utoipa = "5"
 uuid = { version = "1", features = ["v4", "fast-rng", "macro-diagnostics", "serde"] }
 derive-getters = "0"
 async-trait = "0.1"
-tokio = "1"
-ambassador = "0.4"
+tokio = { version = "1", features = ["sync"] }
+ambassador = "0.5"
 
 rstest = "0"
-fake = "4"
+fake = "5"
 rand = "0"
 
 types = { path = "types" }
 
 [dependencies]
 rand = { workspace = true, optional = true }
+fake = { workspace = true, optional = true }
+rstest = { workspace = true, optional = true }
 
 events = { path = "events" }
 common_rest = { path = "common_rest" }
 types = { path = "types" }
 common_telnet = { path = "common_telnet" }
 
-
-
-[features]
-testing = ["rand"]
-
 [dev-dependencies]
 rust_ddd_example_common = { path = ".", features = ["testing"] }
 
-
+[features]
+testing = ["types/testing", "rand", "fake", "rstest"]

--- a/common/types/Cargo.toml
+++ b/common/types/Cargo.toml
@@ -17,6 +17,7 @@ uuid.workspace = true
 derive-getters.workspace = true
 tokio.workspace = true
 async-trait.workspace = true
+ambassador.workspace = true
 
 [dev-dependencies]
 rand.workspace = true

--- a/common/types/Cargo.toml
+++ b/common/types/Cargo.toml
@@ -19,7 +19,12 @@ tokio.workspace = true
 async-trait.workspace = true
 ambassador.workspace = true
 
+rand = { workspace = true, optional = true }
+fake = { workspace = true, optional = true }
+rstest = { workspace = true, optional = true }
+
 [dev-dependencies]
-rand.workspace = true
-rstest.workspace = true
-fake.workspace = true
+types = { path = ".", features = ["testing"] }
+
+[features]
+testing = ["rand", "fake", "rstest"]

--- a/common/types/src/base/domain_entity.rs
+++ b/common/types/src/base/domain_entity.rs
@@ -1,5 +1,6 @@
 use std::fmt::Debug;
 
+use ambassador::delegatable_trait;
 use derivative::Derivative;
 use derive_getters::Getters;
 use derive_new::new;
@@ -28,6 +29,7 @@ impl<T, Event> DomainEntity<T, Event> {
     }
 }
 
+#[delegatable_trait]
 pub trait DomainEntityTrait<Event> {
     /// Add `Event` to a struct
     fn add_event(&mut self, event: Event);

--- a/common/types/src/base/domain_entity.rs
+++ b/common/types/src/base/domain_entity.rs
@@ -102,7 +102,7 @@ mod domain_entity_test {
 
         entity.do_something();
 
-        assert_eq!(entity.domain_entity_field.id.clone(), id.clone());
+        assert_eq!(entity.domain_entity_field.id, id);
         assert_eq!(entity.domain_entity_field.version, version.next());
         let events = entity.domain_entity_field.pop_events();
         assert_eq!(&events.len(), &1);

--- a/delegate_method/Cargo.toml
+++ b/delegate_method/Cargo.toml
@@ -1,0 +1,12 @@
+[package]
+name = "delegate_method"
+version = "0.1.0"
+edition = "2024"
+
+[lib]
+proc-macro = true
+
+[dependencies]
+syn = "2"
+quote = "1"
+proc-macro2 = "1"

--- a/delegate_method/src/lib.rs
+++ b/delegate_method/src/lib.rs
@@ -81,3 +81,77 @@ pub fn delegate_fields(attr: TokenStream, item: TokenStream) -> TokenStream {
 
     output.into()
 }
+
+#[proc_macro_derive(DelegateAllFields, attributes(delegate_target))]
+pub fn derive_delegate_all_fields(item: TokenStream) -> TokenStream {
+    let input = parse_macro_input!(item as DeriveInput);
+    let struct_name = &input.ident;
+
+    let syn::Data::Struct(data_struct) = &input.data else {
+        panic!("Only structs are supported");
+    };
+
+    let delegate_field = data_struct
+        .fields
+        .iter()
+        .find(|f| f.attrs.iter().any(|a| a.path().is_ident("delegate_target")))
+        .expect("No field marked with #[delegate_target]");
+
+    let field_name = delegate_field.ident.as_ref().unwrap();
+
+    let field_ty = &delegate_field.ty;
+
+    let generics = if let syn::Type::Path(type_path) = field_ty {
+        let path = &type_path.path;
+        let last = path.segments.last().unwrap();
+        let args = &last.arguments;
+
+        if let syn::PathArguments::AngleBracketed(angle_args) = args {
+            angle_args
+                .args
+                .iter()
+                .filter_map(|arg| {
+                    if let syn::GenericArgument::Type(ty) = arg {
+                        Some(ty.clone())
+                    } else {
+                        None
+                    }
+                })
+                .collect::<Vec<_>>()
+        } else {
+            panic!("Expected generics on field type");
+        }
+    } else {
+        panic!("Unsupported field type");
+    };
+
+    let id_ty = &generics[0];
+    let version_ty = quote! { Version };
+
+    let methods = vec![
+        (
+            Ident::new("id", proc_macro2::Span::call_site()),
+            quote! { #id_ty },
+        ),
+        (
+            Ident::new("version", proc_macro2::Span::call_site()),
+            version_ty,
+        ),
+    ];
+
+    let method_tokens = methods.into_iter().map(|(method_name, ty)| {
+        quote! {
+            pub fn #method_name(&self) -> &#ty {
+                &self.#field_name.#method_name()
+            }
+        }
+    });
+
+    let output = quote! {
+        impl #struct_name {
+            #(#method_tokens)*
+        }
+    };
+
+    output.into()
+}

--- a/delegate_method/src/lib.rs
+++ b/delegate_method/src/lib.rs
@@ -1,0 +1,83 @@
+use proc_macro::TokenStream;
+use quote::quote;
+use syn::{DeriveInput, Ident, parse_macro_input};
+
+#[proc_macro_attribute]
+pub fn delegate_fields(attr: TokenStream, item: TokenStream) -> TokenStream {
+    let attr_str = attr.to_string().trim().to_string();
+    let field_name = Ident::new(&attr_str, proc_macro2::Span::call_site());
+
+    let item_ast = parse_macro_input!(item as DeriveInput);
+    let struct_name = &item_ast.ident;
+
+    let syn::Data::Struct(data_struct) = &item_ast.data else {
+        panic!("Only structs are supported");
+    };
+
+    let field_ty = data_struct
+        .fields
+        .iter()
+        .find(|f| f.ident.as_ref() == Some(&field_name))
+        .map(|f| &f.ty)
+        .expect("Field not found");
+
+    let generics = if let syn::Type::Path(type_path) = field_ty {
+        let path = &type_path.path;
+        let last = path.segments.last().unwrap();
+        let args = &last.arguments;
+
+        if let syn::PathArguments::AngleBracketed(angle_args) = args {
+            angle_args
+                .args
+                .iter()
+                .filter_map(|arg| {
+                    if let syn::GenericArgument::Type(ty) = arg {
+                        Some(ty.clone())
+                    } else {
+                        None
+                    }
+                })
+                .collect::<Vec<_>>()
+        } else {
+            panic!("Expected generics on field");
+        }
+    } else {
+        panic!("Unsupported field type");
+    };
+
+    if generics.is_empty() {
+        panic!("No generics found in field type");
+    }
+
+    let cart_id_type = &generics[0];
+    let version_type = quote! { Version };
+
+    let methods = vec![
+        (
+            Ident::new("id", proc_macro2::Span::call_site()),
+            quote! { #cart_id_type },
+        ),
+        (
+            Ident::new("version", proc_macro2::Span::call_site()),
+            version_type,
+        ),
+    ];
+
+    let methods = methods.into_iter().map(|(method_name, ty)| {
+        quote! {
+            pub fn #method_name(&self) -> &#ty {
+                &self.#field_name.#method_name()
+            }
+        }
+    });
+
+    let output = quote! {
+        #item_ast
+
+        impl #struct_name {
+            #(#methods)*
+        }
+    };
+
+    output.into()
+}

--- a/shop/.env
+++ b/shop/.env
@@ -2,9 +2,9 @@ LOG_LEVEL=debug
 LOG_FILE=server.log
 HTTP_HOST_URL=http://0.0.0.0:8080
 TELNET_HOST_URL=0.0.0.0:8085
-DATABASE_URL=postgres://root:123@application-db:5432/restappdb
+DATABASE_URL=postgres://root:123@0.0.0.0:5001/restappdb
 #Pref is optional
 #TESTCONTAINERS=keep | remove
 
 RABBITMQ_ADDRESS=amqp://guest:guest@localhost:5672
-KAFKA_ADDRESS=kafka1:9092
+KAFKA_ADDRESS=localhost:9092

--- a/shop/Cargo.toml
+++ b/shop/Cargo.toml
@@ -95,6 +95,7 @@ in_memory_persistence = { path = "in_memory_persistence" }
 rest = { path = "rest" }
 application = { path = "application" }
 telnet = { path = "telnet" }
+delegate_method = {path = "../delegate_method"}
 
 [dependencies]
 application = { path = "application" }

--- a/shop/Cargo.toml
+++ b/shop/Cargo.toml
@@ -55,21 +55,21 @@ serde = { version = "1", features = ["derive", "rc", "alloc"] }
 serde_json = "1.0"
 bigdecimal = { version = "0", features = ["serde"] }
 mockall = "0"
-fake = { version = "4", features = ["derive", "bigdecimal"] }
-rand = "0"
+fake = { version = "5", features = ["derive", "bigdecimal"] }
+rand = "0.10"
 rstest = "0"
 time = { version = "0", features = ["default", "serde-well-known"] }
 enum_delegate = "0"
 smart-default = "0"
 const_format = "0"
-diesel = { version = "2.2", features = ["postgres", "chrono", "numeric"] }# no backend features need to be enabled
-diesel_migrations = "2.2"
+diesel = { version = "=2.2", features = ["postgres", "chrono", "numeric"] }# no backend features need to be enabled
+diesel_migrations = "=2.2"
 diesel_logger = "0.4"
 lapin = "3"
 async-trait = "0"
 futures-lite = "2"
-testcontainers = { version = "0.24", features = ["blocking"] }
-testcontainers-modules = { version = "0.12", features = ["kafka", "postgres", "rabbitmq"] }
+testcontainers = { version = "0.27.0", features = ["blocking"] }
+testcontainers-modules = { version = "0.15.0", features = ["kafka", "postgres", "rabbitmq"] }
 tokio = { version = "1", features = ["full"] }
 tracing = "0"
 tracing-subscriber = "0"
@@ -86,7 +86,7 @@ futures-util = { version = "0", default-features = false, features = ["sink"] }
 utoipa-swagger-ui = { version = "9", features = ["actix-web"] }
 utoipa = { version = "5", features = ["actix_extras", "chrono"] }
 derive-getters = "0"
-ambassador = "0.4"
+ambassador = "0.5"
 
 common = { path = "../common", package = "rust_ddd_example_common" }
 domain = { path = "domain" }
@@ -96,7 +96,6 @@ in_memory_persistence = { path = "in_memory_persistence" }
 rest = { path = "rest" }
 application = { path = "application" }
 telnet = { path = "telnet" }
-delegate_method = { path = "../delegate_method" }
 
 [dependencies]
 application = { path = "application" }

--- a/shop/Cargo.toml
+++ b/shop/Cargo.toml
@@ -86,6 +86,7 @@ futures-util = { version = "0", default-features = false, features = ["sink"] }
 utoipa-swagger-ui = { version = "9", features = ["actix-web"] }
 utoipa = { version = "5", features = ["actix_extras", "chrono"] }
 derive-getters = "0"
+ambassador = "0.4"
 
 common = { path = "../common", package = "rust_ddd_example_common" }
 domain = { path = "domain" }
@@ -95,7 +96,7 @@ in_memory_persistence = { path = "in_memory_persistence" }
 rest = { path = "rest" }
 application = { path = "application" }
 telnet = { path = "telnet" }
-delegate_method = {path = "../delegate_method"}
+delegate_method = { path = "../delegate_method" }
 
 [dependencies]
 application = { path = "application" }

--- a/shop/application/src/configuration/telnet_api_configuration.rs
+++ b/shop/application/src/configuration/telnet_api_configuration.rs
@@ -43,7 +43,7 @@ pub(super) async fn handle_telnet_client(stream: TcpStream) -> Result<(), Box<dy
                     // // ...or just echo back whatever the user has said!
                     _ => {
                         frame
-                            .send(TelnetEvent::Message(format!("You said: {}\n", string)))
+                            .send(TelnetEvent::Message(format!("You said: {string}\n")))
                             .await?;
                     }
                 }

--- a/shop/application/src/configuration/telnet_server_configuration.rs
+++ b/shop/application/src/configuration/telnet_server_configuration.rs
@@ -15,11 +15,11 @@ pub(crate) fn telnet_backend_startup() -> JoinHandle<()> {
                 Ok((stream, _)) => {
                     tokio::spawn(async move {
                         if let Err(e) = handle_telnet_client(stream).await {
-                            error!("error: {}", e);
+                            error!("error: {e}");
                         }
                     });
                 }
-                Err(e) => println!("couldn't get client: {:?}", e),
+                Err(e) => println!("couldn't get client: {e:?}"),
             }
         }
     })

--- a/shop/application/src/configuration/web_api_configuration.rs
+++ b/shop/application/src/configuration/web_api_configuration.rs
@@ -53,7 +53,7 @@ pub struct TokenClaims {
 pub(crate) fn web_api_backend_startup() -> JoinHandle<()> {
     task::spawn(async {
         let http_host_url = env::var("HTTP_HOST_URL").unwrap();
-        info!("Starting HTTP server at {}", http_host_url);
+        info!("Starting HTTP server at {http_host_url}");
 
         let http_host_url = env::var("HTTP_HOST_URL").unwrap();
         let host_url = http_host_url.parse::<Uri>().unwrap();

--- a/shop/application/src/event/kafka_event_publisher_impl.rs
+++ b/shop/application/src/event/kafka_event_publisher_impl.rs
@@ -144,9 +144,10 @@ mod test {
     }
 
     impl MockReceiver {
-        fn new(topic_name: String, test_group: String) -> Self {
+        fn new(topic_name: String, test_group: impl AsRef<str>) -> Self {
+            let test_group = test_group.as_ref();
             let consumer = ClientConfig::new()
-                .set("group.id", test_group.clone())
+                .set("group.id", test_group)
                 .set("bootstrap.servers", KAFKA_ADDRESS.get().unwrap())
                 .set("session.timeout.ms", "6000")
                 .set("enable.auto.commit", "false")

--- a/shop/domain/Cargo.toml
+++ b/shop/domain/Cargo.toml
@@ -17,6 +17,7 @@ uuid.workspace = true
 derive_more.workspace = true
 derive-getters.workspace = true
 async-trait.workspace = true
+ambassador.workspace = true
 
 common.workspace = true
 delegate_method.workspace = true

--- a/shop/domain/Cargo.toml
+++ b/shop/domain/Cargo.toml
@@ -19,6 +19,7 @@ derive-getters.workspace = true
 async-trait.workspace = true
 
 common.workspace = true
+delegate_method.workspace = true
 
 fake = { workspace = true, optional = true }
 rand = { workspace = true, optional = true }

--- a/shop/domain/Cargo.toml
+++ b/shop/domain/Cargo.toml
@@ -20,7 +20,6 @@ async-trait.workspace = true
 ambassador.workspace = true
 
 common.workspace = true
-delegate_method.workspace = true
 
 fake = { workspace = true, optional = true }
 rand = { workspace = true, optional = true }
@@ -28,8 +27,9 @@ rstest = { workspace = true, optional = true }
 mockall = { workspace = true, optional = true }
 
 [dev-dependencies]
-tokio.workspace = true
 domain = { path = ".", features = ["testing"] }
+
+tokio.workspace = true
 
 [features]
 testing = ["common/testing", "fake", "rand", "rstest", "mockall"]

--- a/shop/domain/src/cart/cart.rs
+++ b/shop/domain/src/cart/cart.rs
@@ -1,11 +1,13 @@
-use std::collections::HashMap;
+use std::{
+    collections::HashMap,
+    ops::{Deref, DerefMut},
+};
 
 use ambassador::Delegate;
 use common::types::{
     base::{AM, DomainEntity, DomainEntityTrait, Version, ambassador_impl_DomainEntityTrait},
     common::Count,
 };
-use delegate_method::DelegateAllFields;
 use derive_getters::Getters;
 use serde_derive::{Deserialize, Serialize};
 use smart_default::SmartDefault;
@@ -25,27 +27,30 @@ use crate::{
     menu::{meal::Meal, value_objects::meal_id::MealId},
 };
 
-#[derive(
-    Debug,
-    Clone,
-    PartialEq,
-    SmartDefault,
-    Serialize,
-    Deserialize,
-    Getters,
-    DelegateAllFields,
-    Delegate,
-)]
+#[derive(Debug, Clone, PartialEq, SmartDefault, Serialize, Deserialize, Getters, Delegate)]
 #[delegate(DomainEntityTrait<CartEventEnum>, target = "entity_params")]
 pub struct Cart {
     #[getter(skip)]
-    #[delegate_target]
     pub(crate) entity_params: DomainEntity<CartId, CartEventEnum>,
     #[default(Default::default())]
     pub(crate) for_customer: CustomerId,
     #[default(_code = "OffsetDateTime::now_utc()")]
     pub(crate) created: OffsetDateTime,
     pub(crate) meals: HashMap<MealId, Count>,
+}
+
+impl Deref for Cart {
+    type Target = DomainEntity<CartId, CartEventEnum>;
+
+    fn deref(&self) -> &Self::Target {
+        &self.entity_params
+    }
+}
+
+impl DerefMut for Cart {
+    fn deref_mut(&mut self) -> &mut Self::Target {
+        &mut self.entity_params
+    }
 }
 
 impl Cart {
@@ -69,23 +74,26 @@ impl Cart {
         self.add_event(MealAddedToCartDomainEvent::new(*self.id(), *meal_id).into());
     }
 
-    pub fn update_existing_meal(&mut self, meal_id: &MealId, count: Count) {
+    pub fn update_existing_meal(
+        &mut self,
+        meal_id: &MealId,
+        count: Count,
+    ) -> Result<(), CartError> {
         count
             .increment()
             .map(|increment_count| {
-                if let Some(x) = self.meals.get_mut(meal_id) {
-                    *x = increment_count
-                }
+                *self.meals.get_mut(meal_id).expect("Meal not found in cart") = increment_count;
             })
-            .expect("You have too much the same meals in you cart")
+            .map_err(|_| CartError::TooManyMealsInCart)
     }
-    pub fn add_meal(&mut self, meal: Meal) {
+    pub fn add_meal(&mut self, meal: Meal) -> Result<(), CartError> {
         let meal_id = meal.id();
         let count_of_currently_meals_in_cart = self.meals.get(meal_id);
         if let Some(unwrapped_count) = count_of_currently_meals_in_cart {
             self.update_existing_meal(meal_id, *unwrapped_count)
         } else {
-            self.create_new_meal(meal_id)
+            self.create_new_meal(meal_id);
+            Ok(())
         }
     }
 
@@ -99,6 +107,7 @@ impl Cart {
 #[derive(Debug, PartialEq)]
 pub enum CartError {
     IdGenerationError,
+    TooManyMealsInCart,
 }
 
 #[cfg(test)]
@@ -130,7 +139,7 @@ mod tests {
         let mut cart = rnd_cart();
         let meal = rnd_meal();
 
-        cart.add_meal(meal.clone());
+        cart.add_meal(meal.clone()).unwrap();
         assert!(
             cart.pop_events()
                 .iter()
@@ -149,7 +158,7 @@ mod tests {
         let mut cart = rnd_cart();
         cart.meals.insert(*meal.id(), count);
 
-        cart.add_meal(meal.clone());
+        cart.add_meal(meal.clone()).unwrap();
         assert!(cart.pop_events().iter().all(|event| {
             event == &MealAddedToCartDomainEvent::new(*cart.id(), *meal.id()).into()
         }));

--- a/shop/domain/src/cart/cart.rs
+++ b/shop/domain/src/cart/cart.rs
@@ -4,6 +4,7 @@ use common::types::{
     base::{AM, DomainEntity, DomainEntityTrait, Version},
     common::Count,
 };
+use delegate_method::delegate_fields;
 use derive_getters::Getters;
 use serde_derive::{Deserialize, Serialize};
 use smart_default::SmartDefault;
@@ -24,6 +25,7 @@ use crate::{
 };
 
 #[derive(Debug, Clone, PartialEq, SmartDefault, Serialize, Deserialize, Getters)]
+#[delegate_fields(entity_params)]
 pub struct Cart {
     #[getter(skip)]
     pub(crate) entity_params: DomainEntity<CartId, CartEventEnum>,
@@ -81,15 +83,7 @@ impl Cart {
         }
     }
 
-    pub fn id(&self) -> &CartId {
-        self.entity_params.id()
-    }
-
-    pub fn version(&self) -> &Version {
-        self.entity_params.version()
-    }
-
-    pub(self) fn add_event(&mut self, event: CartEventEnum) {
+    fn add_event(&mut self, event: CartEventEnum) {
         self.entity_params.add_event(event)
     }
 

--- a/shop/domain/src/cart/cart.rs
+++ b/shop/domain/src/cart/cart.rs
@@ -1,10 +1,11 @@
 use std::collections::HashMap;
 
+use ambassador::Delegate;
 use common::types::{
-    base::{AM, DomainEntity, DomainEntityTrait, Version},
+    base::{AM, DomainEntity, DomainEntityTrait, Version, ambassador_impl_DomainEntityTrait},
     common::Count,
 };
-use delegate_method::delegate_fields;
+use delegate_method::DelegateAllFields;
 use derive_getters::Getters;
 use serde_derive::{Deserialize, Serialize};
 use smart_default::SmartDefault;
@@ -24,10 +25,21 @@ use crate::{
     menu::{meal::Meal, value_objects::meal_id::MealId},
 };
 
-#[derive(Debug, Clone, PartialEq, SmartDefault, Serialize, Deserialize, Getters)]
-#[delegate_fields(entity_params)]
+#[derive(
+    Debug,
+    Clone,
+    PartialEq,
+    SmartDefault,
+    Serialize,
+    Deserialize,
+    Getters,
+    DelegateAllFields,
+    Delegate,
+)]
+#[delegate(DomainEntityTrait<CartEventEnum>, target = "entity_params")]
 pub struct Cart {
     #[getter(skip)]
+    #[delegate_target]
     pub(crate) entity_params: DomainEntity<CartId, CartEventEnum>,
     #[default(Default::default())]
     pub(crate) for_customer: CustomerId,
@@ -81,14 +93,6 @@ impl Cart {
         if self.meals.remove(meal_id).is_some() {
             self.add_event(MealRemovedFromCartDomainEvent::new(*self.id(), *meal_id).into())
         }
-    }
-
-    fn add_event(&mut self, event: CartEventEnum) {
-        self.entity_params.add_event(event)
-    }
-
-    pub fn pop_events(&mut self) -> Vec<CartEventEnum> {
-        self.entity_params.pop_events()
     }
 }
 

--- a/shop/domain/src/cart/cart_restorer.rs
+++ b/shop/domain/src/cart/cart_restorer.rs
@@ -46,13 +46,17 @@ mod tests {
 
     #[test]
     fn restore_cart_success() {
+        // given
         let cart_id = rnd_cart_id();
         let guest_id = rnd_customer_id();
         let version = version();
         let meals = HashMap::from([(rnd_meal_id(), rnd_count())]);
         let created = OffsetDateTime::now_utc();
+
+        // when
         let cart = CartRestorer::restore_cart(cart_id, guest_id, created, meals.clone(), version);
 
+        // then
         assert_eq!(cart.id(), &cart_id);
         assert_eq!(cart.for_customer(), &guest_id);
         assert_eq!(cart.version(), &version);

--- a/shop/domain/src/cart/value_objects/cart_id.rs
+++ b/shop/domain/src/cart/value_objects/cart_id.rs
@@ -36,11 +36,14 @@ mod tests {
 
     #[test]
     fn check_equality() {
+        // given
         let id = random_range(0..i64::MAX);
 
+        // when
         let cart_id1 = CartId::try_from(id).unwrap();
         let cart_id2 = CartId::try_from(id).unwrap();
 
+        // then
         assert_eq!(cart_id1, cart_id1);
         assert_eq!(cart_id1.to_i64(), cart_id2.to_i64())
     }

--- a/shop/domain/src/menu/meal.rs
+++ b/shop/domain/src/menu/meal.rs
@@ -4,6 +4,7 @@ use common::types::{
     base::{AM, DomainEntity, DomainEntityTrait, Version},
     errors::BusinessError,
 };
+use delegate_method::delegate_fields;
 use derive_getters::Getters;
 use derive_new::new;
 use serde::{Deserialize, Serialize};
@@ -20,6 +21,7 @@ use crate::menu::{
 };
 
 #[derive(new, Debug, Clone, PartialEq, Default, Serialize, Deserialize, Getters)]
+#[delegate_fields(entity_params)]
 pub struct Meal {
     #[getter(skip)]
     entity_params: DomainEntity<MealId, MealEventEnum>,
@@ -82,14 +84,6 @@ impl Meal {
             self.entity_params
                 .add_event(MealRemovedFromMenuDomainEvent::new(id).into())
         }
-    }
-
-    pub fn id(&self) -> &MealId {
-        self.entity_params.id()
-    }
-
-    pub fn version(&self) -> &Version {
-        self.entity_params.version()
     }
 
     pub fn pop_events(&mut self) -> Vec<MealEventEnum> {

--- a/shop/domain/src/menu/meal.rs
+++ b/shop/domain/src/menu/meal.rs
@@ -1,10 +1,11 @@
 use std::fmt::Debug;
 
+use ambassador::Delegate;
 use common::types::{
-    base::{AM, DomainEntity, DomainEntityTrait, Version},
+    base::{AM, DomainEntity, DomainEntityTrait, Version, ambassador_impl_DomainEntityTrait},
     errors::BusinessError,
 };
-use delegate_method::delegate_fields;
+use delegate_method::DelegateAllFields;
 use derive_getters::Getters;
 use derive_new::new;
 use serde::{Deserialize, Serialize};
@@ -20,10 +21,22 @@ use crate::menu::{
     },
 };
 
-#[derive(new, Debug, Clone, PartialEq, Default, Serialize, Deserialize, Getters)]
-#[delegate_fields(entity_params)]
+#[derive(
+    new,
+    Debug,
+    Clone,
+    PartialEq,
+    Default,
+    Serialize,
+    Deserialize,
+    Getters,
+    DelegateAllFields,
+    Delegate,
+)]
+#[delegate(DomainEntityTrait<MealEventEnum>, target = "entity_params")]
 pub struct Meal {
     #[getter(skip)]
+    #[delegate_target]
     entity_params: DomainEntity<MealId, MealEventEnum>,
     name: MealName,
     description: MealDescription,
@@ -86,9 +99,9 @@ impl Meal {
         }
     }
 
-    pub fn pop_events(&mut self) -> Vec<MealEventEnum> {
-        self.entity_params.pop_events()
-    }
+    // pub fn pop_events(&mut self) -> Vec<MealEventEnum> {
+    //     self.entity_params.pop_events()
+    // }
 }
 
 #[derive(Debug, PartialEq)]

--- a/shop/domain/src/menu/meal.rs
+++ b/shop/domain/src/menu/meal.rs
@@ -1,11 +1,13 @@
-use std::fmt::Debug;
+use std::{
+    fmt::Debug,
+    ops::{Deref, DerefMut},
+};
 
 use ambassador::Delegate;
 use common::types::{
     base::{AM, DomainEntity, DomainEntityTrait, Version, ambassador_impl_DomainEntityTrait},
     errors::BusinessError,
 };
-use delegate_method::DelegateAllFields;
 use derive_getters::Getters;
 use derive_new::new;
 use serde::{Deserialize, Serialize};
@@ -21,28 +23,30 @@ use crate::menu::{
     },
 };
 
-#[derive(
-    new,
-    Debug,
-    Clone,
-    PartialEq,
-    Default,
-    Serialize,
-    Deserialize,
-    Getters,
-    DelegateAllFields,
-    Delegate,
-)]
+#[derive(new, Debug, Clone, PartialEq, Default, Serialize, Deserialize, Getters, Delegate)]
 #[delegate(DomainEntityTrait<MealEventEnum>, target = "entity_params")]
 pub struct Meal {
     #[getter(skip)]
-    #[delegate_target]
     entity_params: DomainEntity<MealId, MealEventEnum>,
     name: MealName,
     description: MealDescription,
     price: Price,
     #[new(value = "false")]
     removed: bool,
+}
+
+impl Deref for Meal {
+    type Target = DomainEntity<MealId, MealEventEnum>;
+
+    fn deref(&self) -> &Self::Target {
+        &self.entity_params
+    }
+}
+
+impl DerefMut for Meal {
+    fn deref_mut(&mut self) -> &mut Self::Target {
+        &mut self.entity_params
+    }
 }
 
 impl Meal {

--- a/shop/domain/src/menu/meal_restorer.rs
+++ b/shop/domain/src/menu/meal_restorer.rs
@@ -30,6 +30,8 @@ impl MealRestorer {
 
 #[cfg(test)]
 mod tests {
+    use common::types::base::DomainEntityTrait;
+
     use super::*;
     use crate::test_fixtures::{
         rnd_meal_description, rnd_meal_id, rnd_meal_name, rnd_price, version,

--- a/shop/domain/src/order/shop_order.rs
+++ b/shop/domain/src/order/shop_order.rs
@@ -1,13 +1,13 @@
 use std::{
     collections::{HashSet, hash_map::DefaultHasher},
     hash::{Hash, Hasher},
+    ops::{Deref, DerefMut},
 };
 
 use common::types::{
-    base::{AM, DomainEntity, DomainEntityTrait, Version},
+    base::{AM, DomainEntity, DomainEntityTrait},
     common::{Address, Count},
 };
-use delegate_method::delegate_fields;
 use derive_getters::Getters;
 use derive_new::new;
 use serde_derive::{Deserialize, Serialize};
@@ -31,7 +31,6 @@ use crate::{
 };
 
 #[derive(new, Debug, Clone, PartialEq, Serialize, Deserialize, SmartDefault, Getters)]
-#[delegate_fields(entity_params)]
 pub struct ShopOrder {
     #[getter(skip)]
     pub(crate) entity_params: DomainEntity<ShopOrderId, ShopOrderEventEnum>,
@@ -41,6 +40,20 @@ pub struct ShopOrder {
     pub(crate) address: Address,
     pub(crate) order_items: HashSet<OrderItem>,
     pub(crate) state: OrderState,
+}
+
+impl Deref for ShopOrder {
+    type Target = DomainEntity<ShopOrderId, ShopOrderEventEnum>;
+
+    fn deref(&self) -> &Self::Target {
+        &self.entity_params
+    }
+}
+
+impl DerefMut for ShopOrder {
+    fn deref_mut(&mut self) -> &mut Self::Target {
+        &mut self.entity_params
+    }
 }
 
 impl ShopOrder {

--- a/shop/domain/src/order/shop_order.rs
+++ b/shop/domain/src/order/shop_order.rs
@@ -7,6 +7,7 @@ use common::types::{
     base::{AM, DomainEntity, DomainEntityTrait, Version},
     common::{Address, Count},
 };
+use delegate_method::delegate_fields;
 use derive_getters::Getters;
 use derive_new::new;
 use serde_derive::{Deserialize, Serialize};
@@ -30,6 +31,7 @@ use crate::{
 };
 
 #[derive(new, Debug, Clone, PartialEq, Serialize, Deserialize, SmartDefault, Getters)]
+#[delegate_fields(entity_params)]
 pub struct ShopOrder {
     #[getter(skip)]
     pub(crate) entity_params: DomainEntity<ShopOrderId, ShopOrderEventEnum>,
@@ -148,15 +150,7 @@ impl ShopOrder {
         matches!(&self.state, Paid(_))
     }
 
-    pub fn id(&self) -> &ShopOrderId {
-        self.entity_params.id()
-    }
-
-    pub fn version(&self) -> &Version {
-        self.entity_params.version()
-    }
-
-    pub(self) fn add_event(&mut self, event: ShopOrderEventEnum) {
+    fn add_event(&mut self, event: ShopOrderEventEnum) {
         self.entity_params.add_event(event)
     }
 

--- a/shop/in_memory_persistence/src/cart/in_memory_cart_repository.rs
+++ b/shop/in_memory_persistence/src/cart/in_memory_cart_repository.rs
@@ -1,7 +1,10 @@
 use std::collections::HashMap;
 
 use async_trait::async_trait;
-use common::{events::DomainEventPublisher, types::base::AM};
+use common::{
+    events::DomainEventPublisher,
+    types::base::{AM, DomainEntityTrait},
+};
 use derivative::Derivative;
 use derive_new::new;
 use domain::cart::{

--- a/shop/in_memory_persistence/src/menu/in_memory_meal_repository.rs
+++ b/shop/in_memory_persistence/src/menu/in_memory_meal_repository.rs
@@ -1,7 +1,10 @@
 use std::{collections::HashMap, fmt::Debug};
 
 use async_trait::async_trait;
-use common::{events::DomainEventPublisher, types::base::AM};
+use common::{
+    events::DomainEventPublisher,
+    types::base::{AM, DomainEntityTrait},
+};
 use derivative::Derivative;
 use derive_new::new;
 use domain::menu::{

--- a/shop/in_memory_persistence/src/test_fixtures.rs
+++ b/shop/in_memory_persistence/src/test_fixtures.rs
@@ -15,7 +15,7 @@ pub fn meal_with_events() -> Meal {
 
 pub fn cart_with_events() -> Cart {
     let mut cart = rnd_cart();
-    cart.add_meal(rnd_meal());
+    cart.add_meal(rnd_meal()).unwrap();
     cart
 }
 

--- a/shop/postgres_persistence/src/postgres_meal_repository.rs
+++ b/shop/postgres_persistence/src/postgres_meal_repository.rs
@@ -1,5 +1,8 @@
 use async_trait::async_trait;
-use common::{events::DomainEventPublisher, types::base::AM};
+use common::{
+    events::DomainEventPublisher,
+    types::base::{AM, DomainEntityTrait},
+};
 use derivative::Derivative;
 use derive_new::new;
 use diesel::{ExpressionMethods, PgConnection, QueryDsl, RunQueryDsl, SelectableHelper};

--- a/shop/usecase/Cargo.toml
+++ b/shop/usecase/Cargo.toml
@@ -25,4 +25,4 @@ tracing-test.workspace = true
 assert-panic.workspace = true
 
 [features]
-testing = ["common/testing", "domain/testing"]
+testing = ["domain/testing"]

--- a/shop/usecase/src/cart/scenarios/add_meal_to_cart_use_case.rs
+++ b/shop/usecase/src/cart/scenarios/add_meal_to_cart_use_case.rs
@@ -57,7 +57,7 @@ where
         let mut cart = self.get_or_create_cart(for_customer).await;
 
         // Add meal to cart
-        cart.add_meal(meal);
+        cart.add_meal(meal).unwrap();
 
         // Persist updated cart
         self.cart_persister.lock().await.save(cart).await;

--- a/shop/usecase/src/test_fixtures.rs
+++ b/shop/usecase/src/test_fixtures.rs
@@ -5,7 +5,10 @@ use std::{
 };
 
 use async_trait::async_trait;
-use common::types::common::{Address, Count};
+use common::types::{
+    base::DomainEntityTrait,
+    common::{Address, Count},
+};
 use derive_new::new;
 use domain::{
     cart::{


### PR DESCRIPTION
This pull request introduces a new `delegate_fields` procedural macro to simplify field delegation in structs. By leveraging this macro, developers can avoid repetitive boilerplate code, improving maintainability and reducing verbosity in the codebase.

- **Added:**
  - A `delegate_fields` procedural macro.

No changes